### PR TITLE
Removed unneeded zalando-incubator for approvals

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -5,7 +5,6 @@ approvals:
       from:
         orgs:
           - "zalando"
-          - "zalando-incubator"
 
 X-Zalando-Team: "payana"
 X-Zalando-Type: code


### PR DESCRIPTION
Only "zalando" should be in the approval organizations