### PR TITLE
made 'id' and 'name' optional as per IETF spec

### DIFF
--- a/src/test/resources/testJsonSchema3.json
+++ b/src/test/resources/testJsonSchema3.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "object": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "item1": {
+          "type": "string"
+        },
+        "item2": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "item1",
+        "item2"
+      ]
+    },
+    "array": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "itemProperty1": {
+            "type": "string"
+          },
+          "itemProperty2": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "structure": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "nestedArray": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "key": {
+                "type": "string",
+                "enum": [
+                  "KEY1",
+                  "KEY2"
+                ]
+              },
+              "value": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "integer": {
+      "type": "integer"
+    },
+    "string": {
+      "type": "string"
+    },
+    "number": {
+      "type": "number"
+    },
+    "float": {
+      "type": "float"
+    },
+    "nullable": {
+      "type": ["number", "null"]
+    },
+    "boolean": {
+      "type": "boolean"
+    },
+    "additionalProperty": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "object",
+    "array",
+    "structure",
+    "typeless",
+    "integer",
+    "string",
+    "number",
+    "nullable",
+    "boolean"
+  ]
+}

--- a/src/test/scala/org/zalando/spark/jsonschema/SchemaConverterTest.scala
+++ b/src/test/scala/org/zalando/spark/jsonschema/SchemaConverterTest.scala
@@ -41,6 +41,12 @@ class SchemaConverterTest extends FunSuite with Matchers {
     assert(testSchema === expectedStruct)
   }
 
+  // 'id' and 'name' are optional according to http://json-schema.org/latest/json-schema-core.html
+  test("should support optional 'id' and 'name' properties") {
+    val testSchema = SchemaConverter.convert("/testJsonSchema3.json")
+    assert(testSchema === expectedStruct)
+  }
+
   test("data fields with only nulls shouldn't be removed") {
     val schema = SchemaConverter.convert("/testJsonSchema2.json")
 


### PR DESCRIPTION
Id and name are optional fields according to the [IETF spec](http://json-schema.org/latest/json-schema-core.html). This change allows them to be optional.