### PR TITLE
Improve arrays' typing

### DIFF
--- a/src/main/scala/org/zalando/spark/jsonschema/SchemaConverter.scala
+++ b/src/main/scala/org/zalando/spark/jsonschema/SchemaConverter.scala
@@ -93,9 +93,9 @@ object SchemaConverter {
         val nullable = array.contains(JsString("null"))
         array.size match {
           case 1 if nullable =>
-            throw new IllegalArgumentException(s"Null type only is not supported")
+            throw new IllegalArgumentException("Null type only is not supported")
           case 1 =>
-            SchemaType(array.head.as[String], nullable = nullable)
+            SchemaType(array.apply(0).as[String], nullable = nullable)
           case 2 if nullable =>
             array.find(_ != JsString("null"))
               .map(i => SchemaType(i.as[String], nullable = nullable))

--- a/src/test/scala/org/zalando/spark/jsonschema/SchemaConverterTest.scala
+++ b/src/test/scala/org/zalando/spark/jsonschema/SchemaConverterTest.scala
@@ -110,4 +110,170 @@ class SchemaConverterTest extends FunSuite with Matchers {
 
     assert(schema === expected)
   }
+
+  test("Known primitive type array should be an array of this type") {
+    val typeMap = Map(
+      "string" -> StringType,
+      "number" -> DoubleType,
+      "float" -> FloatType,
+      "integer" -> LongType,
+      "boolean" -> BooleanType
+    )
+    typeMap.foreach {
+      case p @ (key, datatype) =>
+        val schema = SchemaConverter.convertContent(
+          s"""
+          {
+            "$$schema": "smallTestSchema",
+            "type": "object",
+            "properties": {
+              "array" : {
+                "type" : "array",
+                "items": {
+                  "type": "$key"
+                }
+              }
+            }
+          }
+        """
+        )
+        val expected = StructType(Array(
+          StructField("array", ArrayType(datatype), nullable = false)
+        ))
+
+        assert(schema === expected)
+    }
+  }
+
+  test("Array of array should be an array of array") {
+
+    val schema = SchemaConverter.convertContent(
+      """
+          {
+            "$$schema": "smallTestSchema",
+            "type": "object",
+            "properties": {
+              "array" : {
+                "type" : "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        """
+    )
+    val expected = StructType(Array(
+      StructField("array", ArrayType(ArrayType(StringType)), nullable = false)
+    ))
+
+    assert(schema === expected)
+  }
+
+  test("Array of object should be an array of object") {
+
+    val schema = SchemaConverter.convertContent(
+      """
+          {
+            "$$schema": "smallTestSchema",
+            "type": "object",
+            "properties": {
+              "array" : {
+                "type" : "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        """
+    )
+    val expected = StructType(Array(
+      StructField("array", ArrayType(StructType(Seq.empty)), nullable = false)
+    ))
+
+    assert(schema === expected)
+  }
+
+  test("Array of object with properties should be an array of object with these properties") {
+
+    val schema = SchemaConverter.convertContent(
+      """
+          {
+            "$$schema": "smallTestSchema",
+            "type": "object",
+            "properties": {
+              "array" : {
+                "type" : "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name" : {
+                      "type" : "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        """
+    )
+    val expected = StructType(Array(
+      StructField("array", ArrayType(StructType(Seq(StructField("name", StringType, nullable = false )))), nullable = false)
+    ))
+
+    assert(schema === expected)
+  }
+
+  test("Array of unknown type should be an array of object") {
+
+    val schema = SchemaConverter.convertContent(
+      """
+          {
+            "$$schema": "smallTestSchema",
+            "type": "object",
+            "properties": {
+              "array" : {
+                "type" : "array",
+                "items" : {}
+              }
+            }
+          }
+        """
+    )
+    val expected = StructType(Array(
+      StructField("array", ArrayType(StructType(Seq.empty)), nullable = false)
+    ))
+
+    assert(schema === expected)
+  }
+
+  test("Array of various type should be an array of object") {
+
+    val schema = SchemaConverter.convertContent(
+      """
+          {
+            "$$schema": "smallTestSchema",
+            "type": "object",
+            "properties": {
+              "array" : {
+                "type" : "array",
+                "items" : {
+                  "type" : ["string", "integer"]
+                }
+              }
+            }
+          }
+        """
+    )
+    val expected = StructType(Array(
+      StructField("array", ArrayType(StructType(Seq.empty)), nullable = false)
+    ))
+
+    assert(schema === expected)
+  }
+
 }


### PR DESCRIPTION
Hello :)

In a JSON schema, an array type can declare a "type" property in its  tag.
When parsing the schema, this type has to be respected and therefore an array of a given type should not necessarily result in an array of StructType.

### A bit of context
I recently started using this schema converter to be able to convert some JSON files to Parquet.
My JSON were following their respective jsonschema but at one point I had to store an array of strings.
When I tried to do so, I encountered some exception because parquet was not able to store an empty group.
When I looked at the schema, I found out that my string array were in reality some object arrays.
When I created the schema manually setting the node type to an `ArrayType(StringType)` everything worked smoothly.
So here is a small contribution to fix this issue.