### PR TITLE
#35 Clarify error message

### DIFF
--- a/src/main/scala/org/zalando/spark/jsonschema/SchemaConverter.scala
+++ b/src/main/scala/org/zalando/spark/jsonschema/SchemaConverter.scala
@@ -112,7 +112,8 @@ object SchemaConverter {
           case _ => // Default to string as it is the "safest" type
             SchemaType("string", nullable = nullable)
         }
-      case JsNull => throw new IllegalArgumentException(s"No <$SchemaType> in schema at <$id>")
+      case JsNull =>
+        throw new IllegalArgumentException(s"No <$SchemaFieldType>-field in schema at <$id>")
       case t => throw new IllegalArgumentException(
         s"Unsupported type <${t.toString}> in schema at <$id>"
       )


### PR DESCRIPTION
In a schema without type field on root level, error message before would be

`No <> in schema at </>`

with this PR it should be

`No <type>-field in schema at </>`