### PR TITLE
#39 Updating spark-sql version and testing references

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,13 +5,14 @@ organization := "org.zalando"
 
 scalaVersion := "2.11.8"
 
-libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.0.1"  % Provided
+libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.4.3"  % Provided
 libraryDependencies += "com.typesafe.play" %% "play-json" % "2.5.10"
 dependencyOverrides ++= Set("com.fasterxml.jackson.core" % "jackson-databind" % "2.6.5")
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 
 scapegoatVersion := "1.3.0"
+
 scapegoatIgnoredFiles := Seq(s"${target.value}.*.scala")
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ dependencyOverrides ++= Set("com.fasterxml.jackson.core" % "jackson-databind" % 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 
 scapegoatVersion := "1.3.0"
-
 scapegoatIgnoredFiles := Seq(s"${target.value}.*.scala")
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/src/test/scala/org/zalando/spark/jsonschema/SchemaConverterTest.scala
+++ b/src/test/scala/org/zalando/spark/jsonschema/SchemaConverterTest.scala
@@ -469,4 +469,57 @@ class SchemaConverterTest extends FunSuite with Matchers with BeforeAndAfter {
     }
   }
 
+  test("Reference of multiple types should fail with strict typing") {
+    assertThrows[IllegalArgumentException] {
+      val schema = SchemaConverter.enableStrictTyping().convertContent(
+        """
+          {
+            "definitions": {
+              "address": {
+                "type": ["object", "array"],
+                "properties": {
+                  "street_address": { "type": "string" },
+                  "city":           { "type": "string" },
+                  "state":          { "type": "string" }
+                }
+              }
+            },
+            "type": "object",
+            "properties": {
+              "billing_address": { "$ref": "#/definitions/address" }
+            }
+          }
+        """
+      )
+    }
+  }
+
+  test("Reference of multiple types should default to typing when disable strict typing") {
+    val schema = SchemaConverter.disableStrictTyping().convertContent(
+      """
+          {
+            "definitions": {
+              "address": {
+                "type": ["object", "array"],
+                "properties": {
+                  "street_address": { "type": "string" },
+                  "city":           { "type": "string" },
+                  "state":          { "type": "string" }
+                }
+              }
+            },
+            "type": "object",
+            "properties": {
+              "billing_address": { "$ref": "#/definitions/address" }
+            }
+          }
+        """
+    )
+
+    val expected = StructType(
+      Seq(StructField("billing_address", StringType, nullable = false))
+    )
+
+    assert(schema === expected)
+  }
 }


### PR DESCRIPTION
Updating `spark-sql` version 2.0.1 => 2.4.3

Adding two test cases for references of multiple types. I found not obvious from the tests cases how the conversion of references like the one below will be. So I added two test cases.

```json
          {
            "definitions": {
              "address": {
                "type": ["object", "array"],
                "properties": {
                  "street_address": { "type": "string" },
                  "city":           { "type": "string" },
                  "state":          { "type": "string" }
                }
              }
            },
            "type": "object",
            "properties": {
              "billing_address": { "$ref": "#/definitions/address" }
            }
          }
```